### PR TITLE
Tests upgrade: cross-platform compatibility

### DIFF
--- a/hdes-dialect/hdes-ast/src/test/java/io/resys/hdes/ast/test/DecisionTableTest.java
+++ b/hdes-dialect/hdes-ast/src/test/java/io/resys/hdes/ast/test/DecisionTableTest.java
@@ -83,7 +83,7 @@ public class DecisionTableTest {
   public static void assetNode(ContentNode node, String file) {
     String actual = DataFormatTestUtil.yaml(node);
     String expected = DataFormatTestUtil.file("ast/DecisionTableTest_" + file + ".yaml");
-    Assertions.assertEquals(expected, actual);
+    Assertions.assertLinesMatch(expected.lines(), actual.lines());
   }
 
   public static class ErrorListener extends BaseErrorListener {

--- a/hdes-dialect/hdes-ast/src/test/java/io/resys/hdes/ast/test/ExpressionTest.java
+++ b/hdes-dialect/hdes-ast/src/test/java/io/resys/hdes/ast/test/ExpressionTest.java
@@ -179,7 +179,7 @@ public class ExpressionTest {
   public static void assertNode(ContentNode node, String file) {
     String actual = DataFormatTestUtil.yaml(node);
     String expected = DataFormatTestUtil.file("ast/ExpressionTest_" + file + ".yaml");
-    Assertions.assertEquals(expected, actual);
+    Assertions.assertLinesMatch(expected.lines(), actual.lines());
   }
   
   private static class TestExpressionBuilder {

--- a/hdes-dialect/hdes-interpreter/src/test/java/io/resys/hdes/interpreter/spi/InterpreterTest.java
+++ b/hdes-dialect/hdes-interpreter/src/test/java/io/resys/hdes/interpreter/spi/InterpreterTest.java
@@ -53,7 +53,7 @@ public class InterpreterTest {
     String actual = yaml(execution.getBody());
     //System.out.println(yaml(execution));
     String expected = file(yaml);
-    Assertions.assertEquals(expected, actual);
+    Assertions.assertLinesMatch(expected.lines(), actual.lines());
   }
   
   public void format(TraceEnd end) {

--- a/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/DtRuntimeTest.java
+++ b/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/DtRuntimeTest.java
@@ -39,7 +39,7 @@ public class DtRuntimeTest {
       .value("value1", 2)
       .build();
     
-    Assertions.assertEquals(fileYaml("dtHitPolicyAll"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicyAll").lines(), TestUtil.yaml(output.getBody()).lines());
   }
   
   @Test 
@@ -50,7 +50,7 @@ public class DtRuntimeTest {
         .value("arg", 11)
         .build();
     
-    Assertions.assertEquals(fileYaml("dtHitPolicyFirstBetween"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicyFirstBetween").lines(), TestUtil.yaml(output.getBody()).lines());
   }
   
   
@@ -62,7 +62,7 @@ public class DtRuntimeTest {
         .value("lastName", "blah")
         .build();
 
-    Assertions.assertEquals(fileYaml("dtHitPolicdtHitPolicyFirstyFirst"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicdtHitPolicyFirstyFirst").lines(), TestUtil.yaml(output.getBody()).lines());
   }
 
   @Test 
@@ -75,7 +75,7 @@ public class DtRuntimeTest {
         .value("c", new BigDecimal(10.78).setScale(2, RoundingMode.HALF_UP))
         .build();
     
-    Assertions.assertEquals(fileYaml("dtHitPolicyFirstFormula"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicyFirstFormula").lines(), TestUtil.yaml(output.getBody()).lines());
   }
   
   @Test 
@@ -86,7 +86,7 @@ public class DtRuntimeTest {
         .value("lastName", "blah")
         .build();
 
-    Assertions.assertEquals(fileYaml("dtHitPolicyMatrix"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicyMatrix").lines(), TestUtil.yaml(output.getBody()).lines());
   }
   
   @Test 
@@ -98,7 +98,7 @@ public class DtRuntimeTest {
         .value("name", "BOB")
         .build();
 
-    Assertions.assertEquals(fileYaml("dtHitPolicyMatrixLambdas"), TestUtil.yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("dtHitPolicyMatrixLambdas").lines(), TestUtil.yaml(output.getBody()).lines());
   }
   
   

--- a/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithDecisionAndDtTest.java
+++ b/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithDecisionAndDtTest.java
@@ -37,7 +37,7 @@ public class FlowWithDecisionAndDtTest {
         .value("arg2", 2)
         .build();
 
-    Assertions.assertEquals(fileYaml("flowWithNoSteps"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("flowWithNoSteps").lines(), yaml(output.getBody()).lines());
   }
   
   @Test
@@ -49,7 +49,7 @@ public class FlowWithDecisionAndDtTest {
         .value("arg2", 2)
         .build();
     
-    Assertions.assertEquals(fileYaml("flowWithDecisionAndSplit"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("flowWithDecisionAndSplit").lines(), yaml(output.getBody()).lines());
   }
   
   @Test
@@ -60,7 +60,7 @@ public class FlowWithDecisionAndDtTest {
         .value("arg2", 2)
         .build();
     
-    Assertions.assertEquals(fileYaml("flowWithParalDecisionAndSplit"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("flowWithParalDecisionAndSplit").lines(), yaml(output.getBody()).lines());
   }
   
   private static String fileSrc(String file) {

--- a/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithLoopTest.java
+++ b/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithLoopTest.java
@@ -41,7 +41,7 @@ public class FlowWithLoopTest {
     
     yaml(output.getBody());
     
-    Assertions.assertEquals(fileYaml("loop"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("loop").lines(), yaml(output.getBody()).lines());
     
   }
   

--- a/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithSimpleLoopTest.java
+++ b/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithSimpleLoopTest.java
@@ -41,7 +41,7 @@ public class FlowWithSimpleLoopTest {
     
     yaml(output.getBody());
     
-    Assertions.assertEquals(fileYaml("loop"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("loop").lines(), yaml(output.getBody()).lines());
     
   }
 

--- a/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithWakeUpTest.java
+++ b/hdes-dialect/hdes-runtime/src/test/java/io/resys/hdes/runtime/tests/FlowWithWakeUpTest.java
@@ -54,7 +54,7 @@ public class FlowWithWakeUpTest {
     HashMap<String, Serializable> promiseData = new HashMap<>();
     promiseData.put("userValue", 100);
     output = runner.wakeup().accepts(await.getDataId(), promiseData).build(output);
-    Assertions.assertEquals(fileYaml("simpleFlow"), yaml(output.getBody()));
+    Assertions.assertLinesMatch(fileYaml("simpleFlow").lines(), yaml(output.getBody()).lines());
       
   }
   


### PR DESCRIPTION
### Tests can now be safely run on *nix and Windows systems
- assertions are configured to match lines instead of whole text - `assertEquals()` replaced by `assertLinesMatch()`, in combination with `String.lines()`
- incompatibility between CRLF and LF is thus resolved